### PR TITLE
angular bump; fix typings, and update to tsconfig.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,18 +19,17 @@
   },
   "dependencies": {
     "@ngrx/store": "1.2.1",
-    "angular2": "2.0.0-beta.0",
-    "es6-promise": "3.0.2",
-    "es6-shim": "0.33.13",
+    "angular2": "2.0.0-beta.6",
+    "es6-promise": "3.1.2",
+    "es6-shim": "^0.33.3",
     "es7-reflect-metadata": "1.5.5",
     "reflect-metadata": "0.1.2",
     "rxjs": "5.0.0-beta.0",
-    "zone.js": "0.5.10"
+    "zone.js": "0.5.14"
   },
   "devDependencies": {
     "concurrently": "^1.0.0",
     "css-loader": "^0.23.0",
-    "es6-promise": "^3.0.2",
     "exports-loader": "0.6.2",
     "expose-loader": "^0.7.1",
     "file-loader": "^0.8.4",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES5",
+    "target": "es5",
     "module": "commonjs",
     "removeComments": true,
     "emitDecoratorMetadata": true,
@@ -8,20 +8,12 @@
     "sourceMap": true
   },
   "exclude": [
-    "node_modules"
-  ],
-  "filesGlob": [
-    "client/**/*.ts"
+    "node_modules",
+    "typings/main",
+    "typings/main.d.ts"
   ],
   "compileOnSave": false,
   "atom": {
     "rewriteTsconfig": true
-  },
-  "files": [
-    "client/bootstrap.ts",
-    "client/src/app.ts",
-    "client/src/items.spec.ts",
-    "client/src/items.ts",
-    "client/vendor.ts"
-  ]
+  }
 }

--- a/typings.json
+++ b/typings.json
@@ -4,13 +4,13 @@
   },
   "devDependencies": {},
   "ambientDependencies": {
-    "angular-protractor": "github:angular/DefinitelyTyped/angular-protractor/angular-protractor.d.ts#31e7317c9a0793857109236ef7c7f223305a8aa9",
-    "es6-shim": "github:angular/DefinitelyTyped/es6-shim/es6-shim.d.ts#31e7317c9a0793857109236ef7c7f223305a8aa9",
-    "hammerjs": "github:angular/DefinitelyTyped/hammerjs/hammerjs.d.ts#31e7317c9a0793857109236ef7c7f223305a8aa9",
-    "jasmine": "github:angular/DefinitelyTyped/jasmine/jasmine.d.ts#31e7317c9a0793857109236ef7c7f223305a8aa9",
-    "lodash": "github:angular/DefinitelyTyped/lodash/lodash.d.ts#31e7317c9a0793857109236ef7c7f223305a8aa9",
-    "node": "github:angular/DefinitelyTyped/node/node.d.ts#31e7317c9a0793857109236ef7c7f223305a8aa9",
-    "selenium-webdriver": "github:angular/DefinitelyTyped/selenium-webdriver/selenium-webdriver.d.ts#31e7317c9a0793857109236ef7c7f223305a8aa9",
-    "zone": "github:angular/DefinitelyTyped/zone/zone.d.ts#31e7317c9a0793857109236ef7c7f223305a8aa9"
+    "angular-protractor": "github:DefinitelyTyped/DefinitelyTyped/angular-protractor/angular-protractor.d.ts#17fa1e5f269189f7f8e0f53f8c443e6c2eac562c",
+    "es6-shim": "github:DefinitelyTyped/DefinitelyTyped/es6-shim/es6-shim.d.ts#6697d6f7dadbf5773cb40ecda35a76027e0783b2",
+    "hammerjs": "github:DefinitelyTyped/DefinitelyTyped/hammerjs/hammerjs.d.ts#74a4dfc1bc2dfadec47b8aae953b28546cb9c6b7",
+    "jasmine": "github:DefinitelyTyped/DefinitelyTyped/jasmine/jasmine.d.ts#dd638012d63e069f2c99d06ef4dcc9616a943ee4",
+    "lodash": "github:DefinitelyTyped/DefinitelyTyped/lodash/lodash.d.ts#c8630523ef2ee3fb42fe65cc17af5b1b56e611bc",
+    "node": "github:DefinitelyTyped/DefinitelyTyped/node/node.d.ts#aee0039a2d6686ec78352125010ebb38a7a7d743",
+    "selenium-webdriver": "github:DefinitelyTyped/DefinitelyTyped/selenium-webdriver/selenium-webdriver.d.ts#a83677ed13add14c2ab06c7325d182d0ba2784ea",
+    "zone.js": "github:DefinitelyTyped/DefinitelyTyped/zone.js/zone.js.d.ts#9027703c0bd831319dcdf7f3169f7a468537f448"
   }
 }


### PR DESCRIPTION
Change in tsconfig.json just uses "exclude" property as it satisfies the project.  Using "exclude" and "files" is a schema violation of tsconfig.json (It gives you squiggles on file in VSCode).

In favor of "exclude" as it works in both Atom and VSCode editors.   TS will have "include" property, on roadmap for 2.x 

